### PR TITLE
Check that the block Specific References is not visible when it's empty

### DIFF
--- a/test/mocha/campaigns/PR/9469.js
+++ b/test/mocha/campaigns/PR/9469.js
@@ -1,0 +1,28 @@
+const {HomePage} = require('../../selectors/FO/homePage');
+const {SearchProduct} = require('../../selectors/FO/SearchPage');
+const {ShoppingCartPage} = require('../../selectors/FO/shoppingCartPage');
+const authentication = require('../common_scenarios/authentication');
+const product = require('../common_scenarios/catalog/product');
+
+let productData = {
+  name: 'P1',
+  reference: 'P8710',
+  quantity: '12',
+  priceHT: '20',
+  type: 'standard',
+};
+
+scenario('This scenario is based on the bug described in this PR https://github.com/PrestaShop/PrestaShop/pull/9469', () => {
+  authentication.signInBO('9469');
+  product.createProduct(productData);
+
+  scenario('Check that the block "Specific References" does not appear', client => {
+    test('should go to the Front office', () => client.openShopURL());
+    test('should search for the created product', async () => {
+      await client.waitForAndType(HomePage.search_input, productData.name + global.dateTime);
+      await client.keyboardPress('Enter');
+    });
+    test('should go to the searched product page', () => client.waitForAndClick(SearchProduct.product_result_name));
+    test('should check that "Specific References" does not appear', () => client.isNotExisting(ShoppingCartPage.specific_references));
+  }, 'common_client');
+}, 'common_client', true);

--- a/test/mocha/campaigns/common_scenarios/authentication.js
+++ b/test/mocha/campaigns/common_scenarios/authentication.js
@@ -1,9 +1,9 @@
 module.exports = {
-  async signInBO(testName) {
+  async signInBO(traceName) {
     scenario('Login in the Back Office', client => {
       test('should open the browser', async () => {
         await client.open();
-        await client.startTracing(testName);
+        await client.startTracing(traceName);
       });
       test('should go to the Back office', () => client.accessToBO());
       test('should login successfully in the Back Office', () => client.signInBO());
@@ -16,11 +16,11 @@ module.exports = {
     }, 'common_client');
   },
 
-  async openShop(testName) {
+  async openShop(traceName) {
     scenario('Open the shop', client => {
       test('should open the browser', async () => {
         await client.open();
-        await client.startTracing(testName);
+        await client.startTracing(traceName);
       });
       test('should open the shop', () => client.openShopURL());
     }, 'common_client')

--- a/test/mocha/clients/common_client.js
+++ b/test/mocha/clients/common_client.js
@@ -235,7 +235,7 @@ class CommonClient {
 
   async checkBrowserMessage(textToCheckWith) {
     await page.on('error', error => {
-      console.log(error)
+      console.log(error);
       for (let i = 0; i < msg.args().length; i++) {
         expect(msg.args()[i].to.contain(textToCheckWith))
       }
@@ -244,6 +244,11 @@ class CommonClient {
 
   async isExisting(selector) {
     const exists = await page.$(selector) !== null;
+    expect(exists).to.be.true;
+  }
+
+  async isNotExisting(selector) {
+    const exists = await page.$(selector) === null;
     expect(exists).to.be.true;
   }
 }

--- a/test/mocha/selectors/FO/shoppingCartPage.js
+++ b/test/mocha/selectors/FO/shoppingCartPage.js
@@ -6,6 +6,8 @@ module.exports = {
     quantity_input: '#main  input.js-cart-line-product-quantity',
     cart_products_count: '#_desktop_cart  span.cart-products-count',
     product_name: '#main div.product-line-info > a',
-    block_cart: '#blockcart-modal div.modal-content'
+    block_cart: '#blockcart-modal div.modal-content',
+    product_details_button: '#main li:nth-child(2) > a.nav-link',
+    specific_references: '#product-details > section.product-features > p'
   }
 };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Check that the block Specific References is not visible when it's empty
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/pull/9469
| How to test?  | run: TEST_PATH=PR/9469.js npm run specific-test -- --URL=URLFO