### PR TITLE
Check the help button in the stock page

### DIFF
--- a/test/mocha/campaigns/PR/10260.js
+++ b/test/mocha/campaigns/PR/10260.js
@@ -1,0 +1,20 @@
+const authentication = require('../common_scenarios/authentication');
+const {Menu} = require('../../selectors/BO/menu');
+const {StockPage} = require('../../selectors/BO/catalog/stocks/stock');
+
+/** This scenario is based on the bug described in this PR
+ * https://github.com/PrestaShop/PrestaShop/pull/10260
+ */
+scenario('PR-10260: Check the "Help" button in the stock page', () => {
+  authentication.signInBO('10260');
+  scenario('Check that the "Help" button successfully work', client => {
+    test('should go to "Stock" page', async () => {
+      await client.waitForAndClick(Menu.Sell.Catalog.catalog_menu);
+      await client.waitForAndClick(Menu.Sell.Catalog.stocks_submenu);
+    });
+    test('should click on "Help" button', () => client.waitForAndClick(StockPage.help_button));
+    test('should check that the "Help" sidebar is well opened', () => client.waitFor(StockPage.close_sidebar_button));
+    test('should click on "Close" button of sidebar', () => client.waitForAndClick(StockPage.close_sidebar_button));
+  }, 'common_client');
+  authentication.signOutBO();
+}, 'common_client', true);

--- a/test/mocha/selectors/BO/catalog/stocks/stock.js
+++ b/test/mocha/selectors/BO/catalog/stocks/stock.js
@@ -1,0 +1,6 @@
+module.exports = {
+  StockPage: {
+    help_button: '#app a[title="Help"]',
+    close_sidebar_button: '#ps-quicknav-sidebar a[data-toggle="sidebar"]'
+  }
+};


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR allows to check the "Help" button in the stock page.
| Fixed PR? | https://github.com/PrestaShop/PrestaShop/pull/10260
| How to test?  | Run the script: TEST_PATH=PR/10260.js npm run specific-test -- --URL='http://FrontOfficeURL'