### PR TITLE
Install shop with Uzbek language

### DIFF
--- a/test/mocha/campaigns/PR/10107.js
+++ b/test/mocha/campaigns/PR/10107.js
@@ -1,0 +1,15 @@
+const install = require('../common_scenarios/install');
+
+/** This scenario is based on the bug described in this PR
+ * https://github.com/PrestaShop/PrestaShop/pull/10107
+ */
+scenario('PR-10107: Install shop with Uzbek language', () => {
+  scenario('Open the browser then access to install page', client => {
+    test('should open the browser', async () => {
+      await client.open();
+      await client.startTracing('10107');
+    });
+    test('should go to the install page', () => client.openShopURL(global.installFolderName));
+  }, 'common_client');
+  install.installShop('uz');
+}, 'install', true);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR allows to check the install shop with Uzbek language (uz).
| Fixed PR? | https://github.com/PrestaShop/PrestaShop/pull/10107
| How to test?  | Run the script: TEST_PATH=PR/10107.js npm run specific-test -- --URL='http://FrontOfficeURL' --INSTALL_FOLDER_NAME='/folderName'

Note: the default value of **INSTALL_FOLDER_NAME**: '/install-dev'