### PR TITLE
Install shop with Bosnian language

### DIFF
--- a/test/mocha/campaigns/PR/10105.js
+++ b/test/mocha/campaigns/PR/10105.js
@@ -1,0 +1,15 @@
+const install = require('../common_scenarios/install');
+
+/** This scenario is based on the bug described in this PR
+ * https://github.com/PrestaShop/PrestaShop/pull/10105
+ */
+scenario('PR-10105: Install shop with Bosnian language', () => {
+  scenario('Open the browser then access to install page', client => {
+    test('should open the browser', async () => {
+      await client.open();
+      await client.startTracing('10105');
+    });
+    test('should go to the install page', () => client.openShopURL(global.installFolderName));
+  }, 'common_client');
+  install.installShop('bs');
+}, 'install', true);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR allows to check the install shop with Bosnian language (bs).
| Fixed PR? | https://github.com/PrestaShop/PrestaShop/pull/10105
| How to test?  | Run the script: TEST_PATH=PR/10105.js npm run specific-test -- --URL='http://FrontOfficeURL' --INSTALL_FOLDER_NAME='/folderName'

Note: the default value of **INSTALL_FOLDER_NAME**: '/install-dev'