### PR TITLE
Check the sort of product with drag and drop

### DIFF
--- a/test/mocha/campaigns/PR/10322.js
+++ b/test/mocha/campaigns/PR/10322.js
@@ -1,0 +1,67 @@
+const authentication = require('../common_scenarios/authentication');
+const {Menu} = require('../../selectors/BO/menu');
+const {Catalog} = require('../../selectors/BO/catalog/products/catalog');
+const {CommonBO} = require('../../selectors/BO/commonBO');
+const {HomePage} = require('../../selectors/FO/homePage');
+
+/** This scenario is based on the bug described in this PR
+ * https://github.com/PrestaShop/PrestaShop/pull/10322
+ */
+scenario('PR-10322: Check the sort of product with drag and drop', () => {
+  authentication.signInBO('10322');
+  scenario('Change the position of products with drag and drop', client => {
+    test('should go to "Products" page', async () => {
+      await client.waitForAndClick(Menu.Sell.Catalog.catalog_menu);
+      await client.waitForAndClick(Menu.Sell.Catalog.products_submenu, 4000);
+    });
+    test('should filter the products by category "Home"', async () => {
+      await client.waitForAndClick(Catalog.filter_by_categories_button);
+      await client.waitForAndClick(Catalog.home_category_radio_button, 4000);
+    });
+    test('should click on "Reorder" button', async () => {
+      await client.isVisible(Catalog.product_filter_reorder_button, 2000);
+      if (global.visible) {
+        await client.waitForAndClick(Catalog.product_filter_reorder_button);
+      }
+    });
+    test('should change the position of "' + client.stringifyNumber(3) + ' product" with drag and drop', async () => {
+      await client.getTextInVar(Catalog.product_id.replace('%ID', 3), 'productId', 2000);
+      await client.getTextInVar(Catalog.product_name.replace('%ID', 3), 'productName', 2000);
+      await client.getTextInVar(Catalog.product_reference.replace('%ID', 3), 'productReference', 2000);
+      await client.dragAndDrop(Catalog.product_id.replace('%ID', 3), Catalog.product_id.replace('%ID', 1));
+    });
+    test('should click on "Save & refresh" button', () => client.waitForAndClick(Catalog.product_filter_save_refresh_button, 2000));
+    test('should verify the appearance of the green validation', () => client.checkTextValue(Catalog.success_message, 'Products successfully sorted.'));
+    test('should check that the position of "' + client.stringifyNumber(3) + ' product" has been changed in the Back Office', async () => {
+      await client.checkTextValue(Catalog.product_id.replace('%ID', 1), global.tab['productId'], 'equal', 2000);
+      await client.checkTextValue(Catalog.product_name.replace('%ID', 1), global.tab['productName'], 'equal', 2000);
+      await client.checkTextValue(Catalog.product_reference.replace('%ID', 1), global.tab['productReference'], 'equal', 2000);
+    });
+    test('should go to the Front Office', () => client.accessToFO(CommonBO.shopname_link, 1, 6000));
+    test('should switch language to "English"', () => client.switchShopLanguageInFo('en'));
+    test('should click on "All products" link', () => client.waitForAndClick(HomePage.all_product_link, 50));
+    test('should check that the position of "' + client.stringifyNumber(3) + ' product" has been changed in the Front Office', () => client.checkAttributeValue('#js-product-list article:nth-child(1)', 'data-id-product', global.tab['productId'], 2000));
+    test('should go back to the Back Office', async () => {
+      await client.closeWindow();
+      await client.switchWindow(0);
+    });
+    test('should reset the reorder of product', async () => {
+      await client.waitFor(5000);
+      await client.dragAndDrop(Catalog.product_id.replace('%ID', 3), Catalog.product_id.replace('%ID', 1));
+      await client.dragAndDrop(Catalog.product_id.replace('%ID', 3), Catalog.product_id.replace('%ID', 1));
+      await client.waitForAndClick(Catalog.product_filter_save_refresh_button, 4000);
+    });
+    test('should verify the appearance of the green validation then click on "Close" icon', async () => {
+      await client.checkTextValue(Catalog.success_message, 'Products successfully sorted.');
+      await client.waitForAndClick(Catalog.success_close_button);
+    });
+    test('should click on "' + client.stringifyNumber(3) + ' product" checkbox', () => client.waitForAndClick(Catalog.product_checkbox_button.replace('%ID', 1), 4000));
+    test('should click on "Save & refresh" button', () => client.waitForAndClick(Catalog.product_filter_save_refresh_button, 4000));
+    test('should verify the appearance of the green validation', () => client.checkTextValue(Catalog.success_message, 'Products successfully sorted.'));
+    test('should reset the filter categories of product', async () => {
+      await client.waitForAndClick(Catalog.filter_by_categories_button);
+      await client.waitForAndClick(Catalog.unselect_button, 4000);
+    });
+  }, 'common_client');
+  authentication.signOutBO();
+}, 'common_client', true);

--- a/test/mocha/clients/common_client.js
+++ b/test/mocha/clients/common_client.js
@@ -319,6 +319,26 @@ class CommonClient {
       expect(title).to.equal(textToCheckWith);
     });
   }
+
+  async dragAndDrop(sourceSelector, destinationSelector) {
+    let firstElement = await page.$(sourceSelector);
+    let secondElement = await page.$(destinationSelector);
+    let first_bounding_box = await firstElement.boundingBox();
+    let second_bounding_box = await secondElement.boundingBox();
+    let mouse = page.mouse;
+    await mouse.move(first_bounding_box.x + (first_bounding_box.width / 2), first_bounding_box.y + (first_bounding_box.height / 2));
+    await mouse.down();
+    await mouse.move(second_bounding_box.x + (second_bounding_box.width / 2), second_bounding_box.y + (second_bounding_box.height / 2));
+    await mouse.up();
+  }
+
+  async getTextInVar(selector, globalVar, wait = 0) {
+    await this.waitFor(wait);
+    await this.waitFor(selector);
+    await page.$eval(selector, el => el.innerText).then((text) => {
+      global.tab[globalVar] = text;
+    });
+  }
 }
 
 module.exports = CommonClient;

--- a/test/mocha/selectors/BO/catalog/products/catalog.js
+++ b/test/mocha/selectors/BO/catalog/products/catalog.js
@@ -6,6 +6,57 @@ module.exports = {
     searched_product_link: '#product_catalog_list td:nth-child(4) > a',
     reset_filter_button: '#product_catalog_list  thead[class="with-filters"] button[name="products_filter_reset"]',
     tools_button: '#catalog-tools-button',
-    import_button: '#desc-product-import'
+    import_button: '#desc-product-import',
+    filter_by_categories_button: '#product_catalog_category_tree_filter',
+    home_category_radio_button: '#product_categories_categories > ul > li > div input',
+    unselect_button: '#product_catalog_category_tree_filter_reset',
+    product_table: '#product_catalog_list table.product',
+    get product_checkbox_button() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(1)';
+    },
+    get product_id() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(2) > label';
+    },
+    get product_name() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(4) a';
+    },
+    get product_reference() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(5)';
+    },
+    get product_category() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(6)';
+    },
+    get product_price() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(7) a';
+    },
+    get product_quantity() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(8) a';
+    },
+    get product_status() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(8) a';
+    },
+    get product_filter_name_input() {
+      return this.product_table + ' input[name="filter_column_name"]';
+    },
+    get product_filter_reference_input() {
+      return this.product_table + ' input[name="filter_column_reference"]';
+    },
+    get product_filter_category_input() {
+      return this.product_table + ' input[name="filter_column_name_category"]';
+    },
+    get product_filter_search_button() {
+      return this.product_table + ' button[name="products_filter_submit"]';
+    },
+    get product_filter_reset_button() {
+      return this.product_table + ' button[name="products_filter_reset"]';
+    },
+    get product_filter_reorder_button() {
+      return this.product_table + ' input[value="Reorder"]';
+    },
+    get product_filter_save_refresh_button() {
+      return '#bulk_edition_save_keep';
+    },
+    success_message: 'div.alert-success div.alert-text',
+    success_close_button: 'div.alert-success button.close'
   }
 };

--- a/test/mocha/selectors/FO/homePage.js
+++ b/test/mocha/selectors/FO/homePage.js
@@ -11,6 +11,7 @@ module.exports = {
     order_history_and_details_button: '#history-link',
     sign_out_button: '#_desktop_user_info  a.logout',
     logo_home_page: '#_desktop_logo  img',
-    product_name: 'div.products > article:nth-child(%ID) .h3.product-title > a'
+    product_name: 'div.products > article:nth-child(%ID) .h3.product-title > a',
+    all_product_link: '#content a.all-product-link'
   }
 };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR allows to add a filter by categories, change the position of products with drag and drop then check the sort of products in the BO.
| Fixed PR? | https://github.com/PrestaShop/PrestaShop/pull/10322
| How to test?  | Run the script: TEST_PATH=PR/10322.js npm run specific-test --  --URL 'http://FrontOfficeURL'