### PR TITLE
Check that the checkbox successfully works at the first click in the product page

### DIFF
--- a/test/mocha/campaigns/PR/11071.js
+++ b/test/mocha/campaigns/PR/11071.js
@@ -1,0 +1,33 @@
+const authentication = require('../common_scenarios/authentication');
+const {Menu} = require('../../selectors/BO/menu');
+const {Catalog} = require('../../selectors/BO/catalog/products/catalog');
+
+/** This scenario is based on the bug described in this PR
+ * https://github.com/PrestaShop/PrestaShop/pull/11071
+ */
+scenario('PR-11071: Check that the checkbox successfully works at the first click', () => {
+  authentication.signInBO('11071');
+  scenario('Check that the checkbox successfully works in the product page', client => {
+    test('should go to "Products" page', async () => {
+      await client.waitForAndClick(Menu.Sell.Catalog.catalog_menu);
+      await client.waitForAndClick(Menu.Sell.Catalog.products_submenu, 4000);
+    });
+    test('should filter the products by category "Home"', async () => {
+      await client.waitForAndClick(Catalog.filter_by_categories_button);
+      await client.waitForAndClick(Catalog.home_category_radio_button, 4000);
+    });
+    test('should click on "Reorder" button', async () => {
+      await client.isVisible(Catalog.product_filter_reorder_button, 10000);
+      if (global.visible) {
+        await client.waitForAndClick(Catalog.product_filter_reorder_button);
+      }
+    });
+    test('should click on "' + client.stringifyNumber(1) + ' product" checkbox', () => client.waitForAndClick(Catalog.product_checkbox_button.replace('%ID', 1), 4000));
+    test('should check that the "' + client.stringifyNumber(1) + ' product" is well selected', () => client.isSelected(Catalog.product_checkbox_input.replace('%ID', 1), 4000));
+    test('should reset the filter categories of product', async () => {
+      await client.waitForAndClick(Catalog.filter_by_categories_button);
+      await client.waitForAndClick(Catalog.unselect_button, 4000);
+    });
+  }, 'common_client');
+  authentication.signOutBO();
+}, 'common_client', true);

--- a/test/mocha/clients/common_client.js
+++ b/test/mocha/clients/common_client.js
@@ -339,6 +339,13 @@ class CommonClient {
       global.tab[globalVar] = text;
     });
   }
+
+  async isSelected(selector, wait = 0) {
+    await this.waitFor(wait);
+    await page.$eval(selector, el => el.checked).then((isSelected) => {
+      expect(isSelected).to.be.true;
+    })
+  }
 }
 
 module.exports = CommonClient;

--- a/test/mocha/selectors/BO/catalog/products/catalog.js
+++ b/test/mocha/selectors/BO/catalog/products/catalog.js
@@ -14,6 +14,9 @@ module.exports = {
     get product_checkbox_button() {
       return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(1)';
     },
+    get product_checkbox_input() {
+      return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(1) input';
+    },
     get product_id() {
       return this.product_table + ' tbody tr:nth-child(%ID) td:nth-child(2) > label';
     },


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR allows to add a filter by categories, click on reorder button then check that the checkbox successfully works until the first click in the product page in the BO.
| Fixed PR? | https://github.com/PrestaShop/PrestaShop/pull/11071
| How to test?  | Run the script: TEST_PATH=PR/11071.js npm run specific-test --  --URL 'http://FrontOfficeURL'